### PR TITLE
Adds ability to add a namespace to the store after init

### DIFF
--- a/lib/ReactObservableStore.js
+++ b/lib/ReactObservableStore.js
@@ -83,9 +83,19 @@ var ReactStore = function () {
       var log = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
       this.store.init(data, log);
+      console.log('INIT', data);
       for (var namespace in data) {
         this.strategy.init(namespace);
       }
+    }
+  }, {
+    key: 'add',
+    value: function add(namespace, data) {
+      console.log('ADD', namespace, data);
+      this.store.add(namespace, data);
+      this.strategy.init(namespace);
+      console.log('ADD DONE', this.store.storage);
+      //this.strategy.update(namespace, this.store.get(namespace));
     }
 
     /**

--- a/lib/ReactObservableStore.js
+++ b/lib/ReactObservableStore.js
@@ -83,7 +83,6 @@ var ReactStore = function () {
       var log = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
       this.store.init(data, log);
-      console.log('INIT', data);
       for (var namespace in data) {
         this.strategy.init(namespace);
       }
@@ -91,11 +90,8 @@ var ReactStore = function () {
   }, {
     key: 'add',
     value: function add(namespace, data) {
-      console.log('ADD', namespace, data);
       this.store.add(namespace, data);
       this.strategy.init(namespace);
-      console.log('ADD DONE', this.store.storage);
-      //this.strategy.update(namespace, this.store.get(namespace));
     }
 
     /**

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -92,6 +92,13 @@ var Store = function () {
       if (!data) throw new Error('Invalid store initialization');
       this.storage = (0, _lodash6.default)({}, Store.sanitizeData(data));
     }
+  }, {
+    key: 'add',
+    value: function add(namespace, data) {
+      if (this.storage[namespace]) throw new Error('Namespace exists');
+      this.storage[namespace] = (0, _lodash6.default)({}, Store.sanitizeData(data[namespace]));
+      this.logging();
+    }
 
     /**
      * Method to update the storage data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-observable-store",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ReactObservableStore.js
+++ b/src/ReactObservableStore.js
@@ -57,16 +57,12 @@ class ReactStore {
      */
     init(data, log = false) {
         this.store.init(data, log);
-        console.log('INIT', data);
         for (let namespace in data) this.strategy.init(namespace);
     }
 
     add(namespace, data) {
-        console.log('ADD', namespace, data);
         this.store.add(namespace, data);
         this.strategy.init(namespace);
-        console.log('ADD DONE', this.store.storage);
-        //this.strategy.update(namespace, this.store.get(namespace));
     }
 
     /**

--- a/src/ReactObservableStore.js
+++ b/src/ReactObservableStore.js
@@ -57,7 +57,16 @@ class ReactStore {
      */
     init(data, log = false) {
         this.store.init(data, log);
+        console.log('INIT', data);
         for (let namespace in data) this.strategy.init(namespace);
+    }
+
+    add(namespace, data) {
+        console.log('ADD', namespace, data);
+        this.store.add(namespace, data);
+        this.strategy.init(namespace);
+        console.log('ADD DONE', this.store.storage);
+        //this.strategy.update(namespace, this.store.get(namespace));
     }
 
     /**

--- a/src/Store.js
+++ b/src/Store.js
@@ -59,6 +59,12 @@ class Store {
         this.storage = assign({}, Store.sanitizeData(data));
     }
 
+    add(namespace, data) {
+        if (this.storage[namespace]) throw new Error('Namespace exists');
+        this.storage[namespace] = assign({}, Store.sanitizeData(data[namespace]));
+        this.logging();
+    }
+
     /**
      * Method to update the storage data
      *


### PR DESCRIPTION
Does not appear to result in any race conditions with components subscribing to the store, assuming adding the store is done high enough up in the load order for the add to have been completed. The library adds observers and initializes the store synchronously.

Use case:

Webpack Entry A initializes store with some initial namespaces.

Webpack Entry B loaded separately adds its own namespaces and can subscribe to both stores created by A and B.

For code splitting.